### PR TITLE
output stderr on connection for debugging

### DIFF
--- a/bin/server-start.js
+++ b/bin/server-start.js
@@ -5,6 +5,10 @@ var spawn = require('child_process').spawn,
 
 server.stdout.pipe(process.stdout);
 
+server.stderr.on('data', function(data) {
+    console.log('[' + config.hostname + '] [ERR] ' + data);
+});
+
 server.on('close', function (code) {
     console.log('[' + config.hostname + '] Closed with code: ' + code);
 });


### PR DESCRIPTION
when trying to connect and start `sicksync-remote` on host fails, output the stderr for debugging.